### PR TITLE
change title wording

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -152,7 +152,7 @@ pre .il { color: #40a070 } /* Literal.Number.Integer.Long */.syntax pre .hll { b
     </nav>
     <main class="container-fluid">
       <div class="jumbotron text-center">
-        <h1>Build a Better Gulpfile</h1>
+        <h1>Build Better Gulpfiles</h1>
         <p>asset-builder assembles and orchestrates your dependencies so you
         can run them through your asset pipeline. Easily create gulp tasks you
         can share between projects by separating config from code.</p>


### PR DESCRIPTION
Build a Better Gulpfile -> Build Better Gulpfiles

I like this because of the alliteration, the allusion to extensibility, and the fact that it gets rid of the lowercase "a".

@retlehs I like this better. What do you think?