### PR TITLE
Stripping comments from the json file before parsing it

### DIFF
--- a/lib/readManifest.js
+++ b/lib/readManifest.js
@@ -12,5 +12,6 @@ var p  = require('path');
  * @return {Object} The contents of the JSON file
  */
 module.exports = function(path) {
-  return JSON.parse(fs.readFileSync(p.normalize(path), 'utf8'));
+  var stripJsonComments = require('strip-json-comments');
+  return JSON.parse(stripJsonComments(fs.readFileSync(p.normalize(path), 'utf8')));
 };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "main-bower-files": "^2.4.0",
     "minimatch": "^2.0.1",
     "object-path": "^0.9.0",
+    "strip-json-comments": "^2.0.1",
     "traverse": "^0.6.6"
   }
 }


### PR DESCRIPTION
I wanted to add _comment support_ in manifest.json file of sage, I think it is very usefull as I add a lot of files and remove some of this file.

I had to fork your repository to make it work.
Followed instructions of [swalkinshaw](https://discourse.roots.io/users/swalkinshaw) in [roots's discourse](https://discourse.roots.io/t/implement-strip-json-comments-in-sage/7010/4)

Do you want to merge this into master ?
I don't really want to maintain a fork for this.
